### PR TITLE
Persist Tailscale state in docker-compose-tailscale example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .env
+/tailscale-state

--- a/docker-compose-tailscale.yml
+++ b/docker-compose-tailscale.yml
@@ -14,8 +14,11 @@ services:
       - NET_ADMIN
     devices:
       - /dev/net/tun:/dev/net/tun
+    volumes:
+      - ./tailscale-state:/var/lib/tailscale
     environment:
       - TS_USERSPACE=false
       - TS_AUTHKEY=${TS_AUTHKEY}
+      - TS_STATE_DIR=/var/lib/tailscale
       - TS_ROUTES=${TS_ROUTES:-10.7.0.1/32}
       - TS_EXTRA_ARGS=${TS_EXTRA_ARGS:---snat-subnet-routes=false}


### PR DESCRIPTION
## Summary
- Mount `./tailscale-state:/var/lib/tailscale` on the `sidestore-vpn-tailscale` service so that tailscaled keeps its identity across container recreations.
- Set `TS_STATE_DIR=/var/lib/tailscale` explicitly, matching the official Tailscale docs.
- Add `/tailscale-state` to `.gitignore`.

## Motivation
The current `docker-compose-tailscale.yml` does not persist `/var/lib/tailscale`. Any time the container is recreated (compose change, image update, host reboot if the daemon recreates the container, etc.) tailscaled loses its node identity and tries to log in again using `TS_AUTHKEY`. The failure modes:

- **One-time auth keys** become invalid after the first registration, so on the next recreate `tailscaled` exits with `invalid key: API key ... not valid` and enters a crash loop.
- **Reusable keys** "work" but register a brand-new node each time, leaving orphan machines in the tailnet and requiring the operator to re-approve the `10.7.0.1/32` subnet route after every recreate.

This is also inconsistent with the `docker run` example already in `README.md` for the `:tailscale` image variant, which does mount `-v ./state:/var/lib/tailscale`.

## Reference
Tailscale's official Docker Compose how-to uses the same pattern (volume + `TS_STATE_DIR`) on the `tailscale/tailscale` sidecar so that the container stays logged in after restarts:

https://tailscale.com/docs/features/containers/docker/how-to/connect-docker-container

## Diff
```diff
   sidestore-vpn-tailscale:
     image: tailscale/tailscale:latest
     cap_add:
       - NET_ADMIN
     devices:
       - /dev/net/tun:/dev/net/tun
+    volumes:
+      - ./tailscale-state:/var/lib/tailscale
     environment:
       - TS_USERSPACE=false
       - TS_AUTHKEY=${TS_AUTHKEY}
+      - TS_STATE_DIR=/var/lib/tailscale
       - TS_ROUTES=${TS_ROUTES:-10.7.0.1/32}
       - TS_EXTRA_ARGS=${TS_EXTRA_ARGS:---snat-subnet-routes=false}
```

## Test plan
- [x] Reproduced the crash loop on `master`: container recreate after first successful login → `backend error: invalid key`, container restart loop.
- [x] Applied this patch, re-ran with a fresh auth key → first start authenticates and writes state to `./tailscale-state/`.
- [x] `docker compose down && docker compose up -d` → container comes up `Running` with the same node identity, no re-auth, no new machine in the tailnet, subnet route still approved.
